### PR TITLE
Ecto type

### DIFF
--- a/lib/bow/ecto.ex
+++ b/lib/bow/ecto.ex
@@ -99,6 +99,14 @@ defmodule Bow.Ecto do
         def dump(%{name: name}) do
           {:ok, name}
         end
+
+        def embed_as(_) do
+          :self
+        end
+
+        def equal?(left, right) do
+          left == right
+        end
       end
 
       @behaviour Bow.Ecto

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+{:ok, _} = Application.ensure_all_started(:ecto_sql)
 ExUnit.start(exclude: [:s3, :ecto])


### PR DESCRIPTION
Ecto 3.2 added two callbacks that must be implemented for `Ecto.Type` behaviour