### PR TITLE
[Fix] Fix file extension detection #CU-z41u1q

### DIFF
--- a/lib/bow/download.ex
+++ b/lib/bow/download.ex
@@ -20,7 +20,7 @@ defmodule Bow.Download do
 
             content_type ->
               case MIME.extensions(content_type) do
-                [ext | _] -> Path.rootname(base) <> "." <> ext
+                [ext | _] -> rootname(base) <> "." <> ext
                 _ -> base
               end
           end
@@ -41,6 +41,22 @@ defmodule Bow.Download do
   rescue
     ex in Tesla.Error ->
       {:error, ex}
+  end
+
+  # If path name is malformed, for example looks like this: ".some-data",
+  # we won't be able to extract it and we will treat the name
+  # as file extension instead.
+  #
+  # To handle all kind of problems we simply fallback to auto-generated
+  # name if we cannot read it properly.
+  defp rootname(base) do
+    case Path.rootname(base) do
+      "" ->
+        Ecto.UUID.generate()
+
+      name ->
+        name
+    end
   end
 
   defp encode(url), do: url |> URI.encode() |> String.replace(~r/%25([0-9a-f]{2})/i, "%\\g{1}")

--- a/test/bow/download_test.exs
+++ b/test/bow/download_test.exs
@@ -48,6 +48,15 @@ defmodule Bow.DownloadTest do
                  headers: [{"content-type", "example/dog/nope"}]
              }}
 
+            %{url: "http://example.com/.weird-path"} ->
+              {:ok,
+               %{
+                 env
+                 | status: 200,
+                   body: File.read!(@file_cat),
+                   headers: [{"content-type", "image/png"}]
+               }}
+
           _ ->
             {:ok, %{env | status: 404, body: "NotFound"}}
         end
@@ -91,6 +100,13 @@ defmodule Bow.DownloadTest do
   test "file with invalid content type", %{client: client} do
     assert {:ok, file} = download(client, "http://example.com/dog.jpg")
     assert file.name == "dog.jpg"
+    assert file.path != nil
+    assert File.read!(file.path) == File.read!(@file_cat)
+  end
+
+  test "url with path starting with dot", %{client: client} do
+    assert {:ok, file} = download(client, "http://example.com/.weird-path")
+    assert Regex.match?(~r/.+\.png/, file.name)
     assert file.path != nil
     assert File.read!(file.path) == File.read!(@file_cat)
   end


### PR DESCRIPTION
For broader context please take a look here: https://app.clickup.com/t/z43k1r

## TL:DR

Sometimes we were struggling with generating the name for the downloaded file and would end up with a name like `.pdf` which has been fine until recently

```
OTP 23

Path.extname(".pdf") # => ".pdf"

OTP 24

Path.extname(".pdf") # => ""
```

To deal with this issue, if for whatever reason, we cannot generate the name but still can extract file extension, we will simply generate a random name for the file.